### PR TITLE
fix: Update landing pages to use orz prefix for commands

### DIFF
--- a/landing/docs/index.html
+++ b/landing/docs/index.html
@@ -203,38 +203,38 @@
 
                 <h3>Basic Commands</h3>
                 <div class="command">
-                    <span class="command-name">orzbob</span>
+                    <span class="command-name">orz</span>
                 </div>
                 <p>Run this in a git repository to initialize orzbob and manage your sessions.</p>
 
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">new [branch-name]</span>
+                    <span class="command-name">orz</span> <span class="argument">new [branch-name]</span>
                 </div>
                 <p>Create a new session with the specified branch name. This will create a new git worktree.</p>
 
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">list</span>
+                    <span class="command-name">orz</span> <span class="argument">list</span>
                 </div>
                 <p>List all available sessions.</p>
 
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">switch [session-name]</span>
+                    <span class="command-name">orz</span> <span class="argument">switch [session-name]</span>
                 </div>
                 <p>Switch to an existing session.</p>
 
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">delete [session-name]</span>
+                    <span class="command-name">orz</span> <span class="argument">delete [session-name]</span>
                 </div>
                 <p>Delete a session and its associated git worktree.</p>
 
                 <h3>Advanced Commands</h3>
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">update</span>
+                    <span class="command-name">orz</span> <span class="argument">update</span>
                 </div>
                 <p>Check for and install updates to orzbob.</p>
 
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">help</span>
+                    <span class="command-name">orz</span> <span class="argument">help</span>
                 </div>
                 <p>Display help information about orzbob commands.</p>
 
@@ -279,7 +279,7 @@
                 <h3>How do I update orzbob?</h3>
                 <p>You can update orzbob by running:</p>
                 <div class="command">
-                    <span class="command-name">orzbob</span> <span class="argument">update</span>
+                    <span class="command-name">orz</span> <span class="argument">update</span>
                 </div>
 
                 <h3>Can I use orzbob with non-GitHub repositories?</h3>

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>orz - Become a 100x Engineer</title>
+    <title>orzbob - Become a 100x Engineer</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -59,7 +59,7 @@
 
             <section id="install" class="install-section">
                 <h2>Installation</h2>
-                <p>Install orz with a single command:</p>
+                <p>Install orzbob with a single command:</p>
                 <div class="code-block">
                     <pre><code>curl -fsSL https://raw.githubusercontent.com/carnivoroustoad/orzbob/main/install.sh | bash</code></pre>
                     <button class="copy-button" onclick="copyInstallCommand()">
@@ -67,7 +67,7 @@
                         <span class="copied-text">Copied!</span>
                     </button>
                 </div>
-                <p class="install-note">This will install orz and its dependencies (tmux and GitHub CLI).</p>
+                <p class="install-note">This will install orzbob and its dependencies (tmux and GitHub CLI).</p>
             </section>
 
             <section class="usage">


### PR DESCRIPTION
Fixed landing pages by ensuring all command references use 'orz' as the prefix while keeping the program name as 'orzbob'. This ensures consistency between the landing page and the actual command usage.